### PR TITLE
Fix Shichen nextStartDate day rollover

### DIFF
--- a/Sources/ChineseAstrologyCalendar/Shichen.swift
+++ b/Sources/ChineseAstrologyCalendar/Shichen.swift
@@ -63,8 +63,10 @@ public struct Shichen: Codable {
       [.year, .month, .day, .hour, .minute, .second, .nanosecond],
       from: date)
 
-    if startHour == 23, startDP.hour == 0 {
-      startDP.day = startDP.day! - 1
+    // If the next start hour is earlier than or equal to the current hour,
+    // it belongs to the next day.
+    if let currentHour = startDP.hour, startHour <= currentHour {
+      startDP.day = (startDP.day ?? 0) + 1
     }
 
     startDP.hour = startHour


### PR DESCRIPTION
## Summary
- fix wrong day computation for `Shichen.nextStartDate`

## Testing
- `swift test` *(fails: Failed to clone repository)*

------
https://chatgpt.com/codex/tasks/task_e_683f5236d97483249f2afc4822d86b1d