### PR TITLE
Add invalid month check in YueZhi tests

### DIFF
--- a/Tests/ChineseAstrologyCalendarTests/DateComponentsMonthTests.swift
+++ b/Tests/ChineseAstrologyCalendarTests/DateComponentsMonthTests.swift
@@ -34,6 +34,9 @@ final class DateComponentsMonthTests: XCTestCase {
 
     comps.month = -3
     XCTAssertNil(comps.yueZhi, "yueZhi should be nil for a negative month")
+
+    comps.month = 13
+    XCTAssertNil(comps.yueZhi, "yueZhi should be nil for month greater than 12")
   }
 
   // MARK: - yueGan Tests


### PR DESCRIPTION
## Summary
- extend `testYueZhiInvalidMonth` to check months above 12

## Testing
- `swift test` *(fails: network unreachable while fetching dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_683f534af830832484b13b8ef83c9c1e