### PR TITLE
Fix constant name for Chinese locale

### DIFF
--- a/Sources/ChineseAstrologyCalendar/DizhiGanzhi/Dizhi.swift
+++ b/Sources/ChineseAstrologyCalendar/DizhiGanzhi/Dizhi.swift
@@ -306,7 +306,7 @@ extension Dizhi: TimeExpressible {
 
   static var monthFormatter: DateFormatter = {
     let dfm = DateFormatter()
-    dfm.locale = tranditonalChineseLocal
+    dfm.locale = traditionalChineseLocale
     dfm.dateFormat = "MMMM"
     return dfm
   }()

--- a/Sources/ChineseAstrologyCalendar/Event/EventModel.swift
+++ b/Sources/ChineseAstrologyCalendar/Event/EventModel.swift
@@ -29,7 +29,7 @@ extension EventModel {
 
   private static var enToChNumberFormatter: NumberFormatter {
     let formatter = NumberFormatter()
-    formatter.locale = tranditonalChineseLocal
+    formatter.locale = traditionalChineseLocale
     formatter.numberStyle = .spellOut
     return formatter
   }

--- a/Sources/ChineseAstrologyCalendar/NumberFormater+Text.swift
+++ b/Sources/ChineseAstrologyCalendar/NumberFormater+Text.swift
@@ -1,3 +1,3 @@
 import Foundation
 
-public let tranditonalChineseLocal = Locale(identifier: "zh_Hant_CN")
+public let traditionalChineseLocale = Locale(identifier: "zh_Hant_CN")


### PR DESCRIPTION
## Summary
- fix typo `tranditonalChineseLocal` -> `traditionalChineseLocale`
- update references in Dizhi and EventModel

## Testing
- `swift test` *(fails: network unreachable for dependency)*

------
https://chatgpt.com/codex/tasks/task_e_683f535c01888324a41ab73f9949f51b