### PR TITLE
Fix month/year calc & add range test

### DIFF
--- a/Sources/ChineseAstrologyCalendar/Date/DayConverter.swift
+++ b/Sources/ChineseAstrologyCalendar/Date/DayConverter.swift
@@ -18,11 +18,10 @@ public final class DayConverter {
       for d in days {
         var copy = components
 
-        let newMonth = (copy.month! + month)
-        let newYear: Float = (Float(newMonth) / 13.0).rounded(.towardZero)
-
-        copy.month = newMonth <= 12 ? newMonth : newMonth - 12
-        copy.year! += Int(newYear)
+        let newMonth = copy.month! + month
+        let newYear = (newMonth - 1) / 12
+        copy.month = ((newMonth - 1) % 12) + 1
+        copy.year! += newYear
         copy.day = d.rawValue
 
         guard

--- a/Sources/ChineseAstrologyCalendar/Date/DayConverter.swift
+++ b/Sources/ChineseAstrologyCalendar/Date/DayConverter.swift
@@ -19,8 +19,8 @@ public final class DayConverter {
         var copy = components
 
         let newMonth = copy.month! + month
-        let newYear = (newMonth - 1) / 12
-        copy.month = ((newMonth - 1) % 12) + 1
+        let (newYear, adjustedMonth) = calculateYearAndMonth(fromMonth: copy.month!, offset: month)
+        copy.month = adjustedMonth
         copy.year! += newYear
         copy.day = d.rawValue
 

--- a/Tests/ChineseAstrologyCalendarTests/DayConverterTests.swift
+++ b/Tests/ChineseAstrologyCalendarTests/DayConverterTests.swift
@@ -70,6 +70,21 @@ class DayConverterTests: XCTestCase {
       ])
   }
 
+  func testRangeExceedingTwelveMonths() throws {
+    let monthsHasSanshi = dateConverter.find(days: [.sanshi], inNextMonths: 14, from: calendar.date(from: testDate)!)
+      .map { formatter.string(from: $0.date) }
+
+    XCTAssertEqual(monthsHasSanshi, [
+      "3/2/22",
+      "4/30/22",
+      "6/28/22",
+      "7/28/22",
+      "9/25/22",
+      "11/23/22",
+      "1/21/23",
+    ])
+  }
+
   func testOneDateAndMonthEarlierThanNow() throws {
     let testDate = DateComponents(calendar: Calendar.current, year: 2022, month: 1, day: 16, hour: 6, minute: 7)
 


### PR DESCRIPTION
## Summary
- fix month and year math in `DayConverter.find` using integer arithmetic
- test day lookup across more than twelve months

## Testing
- `swift test` *(fails: Failed to clone repository git@github.com:xiangyu-sun/BaGua.git: ... network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_683f535a36dc8324a459013df2fc215f