### PR TITLE
Add release asset upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
 
     - name: Build and Test
       run: |
-        swift build
+        swift build -c release
         swift test
 
     - name: Create Release
@@ -32,6 +32,20 @@ jobs:
         release_name: Release ${{ github.ref }}
         draft: false
         prerelease: false
+
+    - name: Archive release build
+      run: |
+        zip -r ChineseAstrologyCalendar.zip .build/release
+
+    - name: Upload Release Asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./ChineseAstrologyCalendar.zip
+        asset_name: ChineseAstrologyCalendar.zip
+        asset_content_type: application/zip
 
     # Add any additional steps for packaging your software, if necessary
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ More examples can be found in the unit tests inside the `Tests` directory.
 swift test
 ```
 
+## Releases
+
+Pushing a tag that matches `v*` automatically triggers the release workflow.
+The workflow builds the package, creates a GitHub release and uploads a
+`ChineseAstrologyCalendar.zip` archive containing the release build.
+
 ## License
 
 Licensed under the [MIT License](LICENSE.md).


### PR DESCRIPTION
## Summary
- archive the release build and attach it to each GitHub Release
- document the automated release flow in the README

## Testing
- `swift test` *(fails: network unreachable while cloning BaGua dependency)*

------
https://chatgpt.com/codex/tasks/task_e_685aa551d9148324aa01ee061c66b06f